### PR TITLE
Boot default entry when Esc is pressed on FrontPage

### DIFF
--- a/IntelFrameworkModulePkg/Universal/BdsDxe/FrontPage.c
+++ b/IntelFrameworkModulePkg/Universal/BdsDxe/FrontPage.c
@@ -1325,7 +1325,12 @@ PlatformBdsEnterFrontPage (
     //
     UpdateFrontPageStrings ();
 
-    gCallbackKey = 0;
+    //
+    // Default to continuing booting so the user can boot the default entry by
+    // exiting the form using the Escape key.
+    //
+    //gCallbackKey = 0;
+    gCallbackKey = FRONT_PAGE_KEY_CONTINUE;
     CallFrontPage ();
 
     //


### PR DESCRIPTION
Resolves: system76/firmware-open#22