### PR TITLE
Add warning if no bootable media found

### DIFF
--- a/IntelFrameworkModulePkg/Universal/BdsDxe/BootMngr/BootManager.c
+++ b/IntelFrameworkModulePkg/Universal/BdsDxe/BootMngr/BootManager.c
@@ -205,6 +205,7 @@ CallBootManager (
   EFI_STRING_ID               Token;
   UINTN                       Index;
   EFI_INPUT_KEY               Key;
+  CHAR16                      *WarningString;
   CHAR16                      *HelpString;
   UINTN                       HelpSize;
   EFI_STRING_ID               HelpToken;
@@ -265,6 +266,14 @@ CallBootManager (
   EndLabel = (EFI_IFR_GUID_LABEL *) HiiCreateGuidOpCode (EndOpCodeHandle, &gEfiIfrTianoGuid, NULL, sizeof (EFI_IFR_GUID_LABEL));
   EndLabel->ExtendOpCode = EFI_IFR_EXTEND_OP_LABEL;
   EndLabel->Number       = LABEL_BOOT_OPTION_END;
+
+  if (IsListEmpty (&mBootOptionsList)) {
+    WarningString = AllocateZeroPool (0x60);
+    StrCatS (WarningString, 0x60 / sizeof (CHAR16), L"No bootable media found");
+    Token = HiiSetString (HiiHandle, STRING_TOKEN (STR_NO_BOOTABLE_MEDIA), WarningString, NULL);
+    FreePool (WarningString);
+    HiiCreateSubTitleOpCode (StartOpCodeHandle, Token, 0, 0, 0);
+  }
 
   mKeyInput = 0;
   NeedEndOp = FALSE;

--- a/IntelFrameworkModulePkg/Universal/BdsDxe/FrontPage.c
+++ b/IntelFrameworkModulePkg/Universal/BdsDxe/FrontPage.c
@@ -885,6 +885,30 @@ GetDeviceNameFromProduct (
   //etc etc
 }
 
+VOID
+WarnNoBootableMedia (
+  VOID
+  )
+{
+  CHAR16              *NewString;
+  EFI_STRING_ID       TokenToUpdate;
+  LIST_ENTRY          BootList;
+
+  InitializeListHead (&BootList);
+  BdsLibBuildOptionFromVar (&BootList, L"BootOrder");
+
+  NewString = AllocateZeroPool (0x60);
+
+  if (IsListEmpty (&BootList)) {
+    StrCatS (NewString, 0x60 / sizeof (CHAR16), L"Warning: No bootable media found");
+  } else {
+    StrCatS (NewString, 0x60 / sizeof (CHAR16), L"");
+  }
+
+  TokenToUpdate = STRING_TOKEN (STR_NO_BOOTABLE_MEDIA);
+  HiiSetString (gFrontPagePrivate.HiiHandle, TokenToUpdate, NewString, NULL);
+  FreePool (NewString);
+}
 
 /**
   Update the banner information for the Front Page based on DataHub information.
@@ -908,6 +932,8 @@ UpdateFrontPageStrings (
   UINT64                            InstalledMemory;
 
   InstalledMemory = 0;
+
+  WarnNoBootableMedia ();
 
   //
   // Update Front Page strings

--- a/IntelFrameworkModulePkg/Universal/BdsDxe/FrontPageStrings.uni
+++ b/IntelFrameworkModulePkg/Universal/BdsDxe/FrontPageStrings.uni
@@ -68,3 +68,4 @@
                                        #language fr-FR  "Le procédé de botte continuera dans %d secondes"
 #string STR_MISSING_STRING             #language en-US  "Missing String"
                                        #language fr-FR  "Missing String"
+#string STR_NO_BOOTABLE_MEDIA          #language en-US  ""

--- a/IntelFrameworkModulePkg/Universal/BdsDxe/FrontPageVfr.Vfr
+++ b/IntelFrameworkModulePkg/Universal/BdsDxe/FrontPageVfr.Vfr
@@ -93,6 +93,9 @@ formset
       flags   = INTERACTIVE,
       key     = FRONT_PAGE_KEY_BOOT_MAINTAIN;
 
+    subtitle text = STRING_TOKEN(STR_NULL_STRING);
+    subtitle text = STRING_TOKEN(STR_NO_BOOTABLE_MEDIA);
+
   endform;
 
 endformset;


### PR DESCRIPTION
Resolves: system76/firmware-open#6

![Screenshot from 2020-01-29 07-58-43](https://user-images.githubusercontent.com/5222085/73367934-6e712a00-426d-11ea-925b-5f4749e27711.png)
![Screenshot from 2020-01-29 10-12-51](https://user-images.githubusercontent.com/5222085/73379675-ef392180-427f-11ea-9014-668b2a6a76a3.png)
