### PR TITLE
Save BootOrder on list update

### DIFF
--- a/MdeModulePkg/Library/BootMaintenanceManagerUiLib/BootMaintenance.c
+++ b/MdeModulePkg/Library/BootMaintenanceManagerUiLib/BootMaintenance.c
@@ -1253,6 +1253,11 @@ BootMaintCallback (
       CurrentFakeNVMap->DriverOptionChanged = TRUE;
     }
 
+    if (QuestionId == BOOT_OPTION_ORDER_QUESTION_ID) {
+        // Save BootOrder on list update
+        *ActionRequest = EFI_BROWSER_ACTION_REQUEST_FORM_APPLY;
+    }
+
     if ((QuestionId >= BOOT_OPTION_DEL_QUESTION_ID) && (QuestionId < BOOT_OPTION_DEL_QUESTION_ID + MAX_MENU_NUMBER)) {
       if (Value->b){
         //

--- a/MdeModulePkg/Library/BootMaintenanceManagerUiLib/BootMaintenance.c
+++ b/MdeModulePkg/Library/BootMaintenanceManagerUiLib/BootMaintenance.c
@@ -1646,6 +1646,28 @@ BmmInitialBootModeInfo (
   mBmmModeInitialized           = TRUE;
 }
 
+STATIC
+EFI_STATUS
+UnregisterHotKeys(VOID)
+{
+  EFI_STATUS Status;
+  EFI_INPUT_KEY HotKey;
+  EDKII_FORM_BROWSER_EXTENSION2_PROTOCOL *FormBrowserEx2;
+
+  Status = gBS->LocateProtocol (&gEdkiiFormBrowserEx2ProtocolGuid, NULL, (VOID **) &FormBrowserEx2);
+  if (!EFI_ERROR (Status)) {
+    HotKey.UnicodeChar = CHAR_NULL;
+
+    HotKey.ScanCode = SCAN_F9;
+    FormBrowserEx2->RegisterHotKey(&HotKey, BROWSER_ACTION_UNREGISTER, 0, NULL);
+
+    HotKey.ScanCode = SCAN_F10;
+    FormBrowserEx2->RegisterHotKey(&HotKey, BROWSER_ACTION_UNREGISTER, 0, NULL);
+  }
+
+  return Status;
+}
+
 /**
 
   Install Boot Maintenance Manager Menu driver.
@@ -1733,6 +1755,11 @@ BootMaintenanceManagerUiLibConstructor (
   InitializeBmmConfig(mBmmCallbackInfo);
 
   BmmInitialBootModeInfo();
+
+  //
+  // Remove the F9 and F10 hotkeys
+  //
+  UnregisterHotKeys();
 
   return EFI_SUCCESS;
 }

--- a/MdeModulePkg/Library/BootMaintenanceManagerUiLib/BootMaintenance.c
+++ b/MdeModulePkg/Library/BootMaintenanceManagerUiLib/BootMaintenance.c
@@ -722,6 +722,7 @@ BootMaintExtractConfig (
     *Progress = Request + StrLen (Request);
   }
 
+  DEBUG ((EFI_D_INFO, "%a complete: %r\n", __FUNCTION__, Status));
   return Status;
 }
 
@@ -1033,6 +1034,7 @@ BootMaintRouteConfig (
   //
   CopyMem (OldBmmData, NewBmmData, sizeof (BMM_FAKE_NV_DATA));
 
+  DEBUG ((EFI_D_INFO, "%a complete: %r\n", __FUNCTION__, Status));
   return EFI_SUCCESS;
 
 Exit:
@@ -1093,6 +1095,8 @@ BootMaintCallback (
   Private        = BMM_CALLBACK_DATA_FROM_THIS (This);
 
   if (Action == EFI_BROWSER_ACTION_FORM_OPEN) {
+    DEBUG ((EFI_D_INFO, "EFI_BROWSER_ACTION_FORM_OPEN: 0x%0X\n", QuestionId));
+
     if (QuestionId == KEY_VALUE_TRIGGER_FORM_OPEN_ACTION) {
       if (!mFirstEnterBMMForm) {
         //
@@ -1121,6 +1125,8 @@ BootMaintCallback (
   HiiGetBrowserData (&mBootMaintGuid, mBootMaintStorageName, sizeof (BMM_FAKE_NV_DATA), (UINT8 *) CurrentFakeNVMap);
 
   if (Action == EFI_BROWSER_ACTION_CHANGING) {
+    DEBUG ((EFI_D_INFO, "EFI_BROWSER_ACTION_CHANGING: 0x%0X\n", QuestionId));
+
     if (Value == NULL) {
       return EFI_INVALID_PARAMETER;
     }
@@ -1206,6 +1212,8 @@ BootMaintCallback (
       ChooseFile (NULL, L".efi", BootFromFile, &File);
     }
   } else if (Action == EFI_BROWSER_ACTION_CHANGED) {
+    DEBUG ((EFI_D_INFO, "EFI_BROWSER_ACTION_CHANGED: 0x%0X\n", QuestionId));
+
     if ((Value == NULL) || (ActionRequest == NULL)) {
       return EFI_INVALID_PARAMETER;
     }
@@ -1308,6 +1316,7 @@ BootMaintCallback (
   //
   HiiSetBrowserData (&mBootMaintGuid, mBootMaintStorageName, sizeof (BMM_FAKE_NV_DATA), (UINT8 *) CurrentFakeNVMap, NULL);
 
+  DEBUG ((EFI_D_INFO, "%a complete: %r\n", __FUNCTION__, EFI_SUCCESS));
   return EFI_SUCCESS;
 }
 

--- a/MdeModulePkg/Library/BootMaintenanceManagerUiLib/UpdatePage.c
+++ b/MdeModulePkg/Library/BootMaintenanceManagerUiLib/UpdatePage.c
@@ -115,36 +115,36 @@ UpdatePageEnd (
   //
   // Create the "Apply changes" and "Discard changes" tags.
   //
-  if (CallbackData->BmmAskSaveOrNot) {
-    HiiCreateSubTitleOpCode (
-      mStartOpCodeHandle,
-      STRING_TOKEN (STR_NULL_STRING),
-      0,
-      0,
-      0
-      );
+  //if (CallbackData->BmmAskSaveOrNot) {
+  //  HiiCreateSubTitleOpCode (
+  //    mStartOpCodeHandle,
+  //    STRING_TOKEN (STR_NULL_STRING),
+  //    0,
+  //    0,
+  //    0
+  //    );
 
-    HiiCreateActionOpCode (
-      mStartOpCodeHandle,
-      KEY_VALUE_SAVE_AND_EXIT,
-      STRING_TOKEN (STR_SAVE_AND_EXIT),
-      STRING_TOKEN (STR_NULL_STRING),
-      EFI_IFR_FLAG_CALLBACK,
-      0
-      );
-  }
+  //  HiiCreateActionOpCode (
+  //    mStartOpCodeHandle,
+  //    KEY_VALUE_SAVE_AND_EXIT,
+  //    STRING_TOKEN (STR_SAVE_AND_EXIT),
+  //    STRING_TOKEN (STR_NULL_STRING),
+  //    EFI_IFR_FLAG_CALLBACK,
+  //    0
+  //    );
+  //}
 
   //
   // Ensure user can return to the main page.
   //
-  HiiCreateActionOpCode (
-    mStartOpCodeHandle,
-    KEY_VALUE_NO_SAVE_AND_EXIT,
-    STRING_TOKEN (STR_NO_SAVE_AND_EXIT),
-    STRING_TOKEN (STR_NULL_STRING),
-    EFI_IFR_FLAG_CALLBACK,
-    0
-    );
+  //HiiCreateActionOpCode (
+  //  mStartOpCodeHandle,
+  //  KEY_VALUE_NO_SAVE_AND_EXIT,
+  //  STRING_TOKEN (STR_NO_SAVE_AND_EXIT),
+  //  STRING_TOKEN (STR_NULL_STRING),
+  //  EFI_IFR_FLAG_CALLBACK,
+  //  0
+  //  );
 
   HiiUpdateForm (
     CallbackData->BmmHiiHandle,

--- a/MdeModulePkg/Library/BootMaintenanceManagerUiLib/UpdatePage.c
+++ b/MdeModulePkg/Library/BootMaintenanceManagerUiLib/UpdatePage.c
@@ -642,7 +642,7 @@ UpdateOrderPage (
       VarOffset,                                   // Offset in Buffer Storage
       STRING_TOKEN (STR_CHANGE_ORDER),             // Question prompt text
       STRING_TOKEN (STR_CHANGE_ORDER),             // Question help text
-      0,                                           // Question flag
+      EFI_IFR_FLAG_CALLBACK,                       // Question flag
       0,                                           // Ordered list flag, e.g. EFI_IFR_UNIQUE_SET
       EFI_IFR_TYPE_NUM_SIZE_32,                    // Data type of Question value
       100,                                         // Maximum container

--- a/MdeModulePkg/Library/BootMaintenanceManagerUiLib/Variable.c
+++ b/MdeModulePkg/Library/BootMaintenanceManagerUiLib/Variable.c
@@ -631,6 +631,7 @@ Var_UpdateBootOrder (
   BOpt_FreeMenu (&BootOptionMenu);
   BOpt_GetBootOptions (CallbackData);
 
+  DEBUG ((EFI_D_INFO, "Updated BootOrder: %r\n", Status));
   return Status;
 
 }


### PR DESCRIPTION
Save BootOrder when confirming the list order (pressing Enter) in Change Boot Order. Remove the now redundant "Commit/Discard Changes on Exit" buttons and hotkeys.

Ref: system76/firmware-open#65

```
0: Enter
modified: <snip>
selected: 0x7d8e2698, action: 0x0
EFI_BROWSER_ACTION_CHANGING: 0x153C
BootMaintCallback complete: Success
EFI_BROWSER_ACTION_CHANGED: 0x153C
BootMaintCallback complete: Success
Updated BootOrder: Success
BootMaintRouteConfig complete: Success
```

![Screenshot from 2020-07-08 10-32-33](https://user-images.githubusercontent.com/5222085/86945536-5f3cb500-c106-11ea-9987-946484fe685d.png)
