### PR TITLE
UefiPayloadPkg: Stall before connecting devices

### DIFF
--- a/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
+++ b/UefiPayloadPkg/Library/PlatformBootManagerLib/PlatformBootManager.c
@@ -196,6 +196,9 @@ PlatformBootManagerAfterConsole (
   gST->ConOut->ClearScreen (gST->ConOut);
   BootLogoEnableLogo ();
 
+  // FIXME: USB devices are not being detected unless we wait a bit.
+  gBS->Stall (100 * 1000);
+
   EfiBootManagerConnectAll ();
   EfiBootManagerRefreshAllBootOption ();
 


### PR DESCRIPTION
Add back boot device detection hack. Should help with system76/firmware-open#23.

USB devices are not being detected when booting. Pause a bit for them to be initialized and detected by `EfiBootManagerConnectAll()`.
