### PR TITLE
Fix compiling BaseTools with GCC 12

### DIFF
--- a/BaseTools/Source/C/DevicePath/GNUmakefile
+++ b/BaseTools/Source/C/DevicePath/GNUmakefile
@@ -13,8 +13,13 @@ OBJECTS = DevicePath.o UefiDevicePathLib.o DevicePathFromText.o  DevicePathUtili
 
 include $(MAKEROOT)/Makefiles/app.makefile
 
+GCCVERSION = $(shell gcc -dumpversion | awk -F'.' '{print $$1}')
+ifneq ("$(GCCVERSION)", "5")
+ifneq ($(CXX), llvm)
 # gcc 12 trips over device path handling
 BUILD_CFLAGS += -Wno-error=stringop-overflow
+endif
+endif
 
 LIBS = -lCommon
 ifeq ($(CYGWIN), CYGWIN)

--- a/BaseTools/Source/C/DevicePath/GNUmakefile
+++ b/BaseTools/Source/C/DevicePath/GNUmakefile
@@ -13,6 +13,9 @@ OBJECTS = DevicePath.o UefiDevicePathLib.o DevicePathFromText.o  DevicePathUtili
 
 include $(MAKEROOT)/Makefiles/app.makefile
 
+# gcc 12 trips over device path handling
+BUILD_CFLAGS += -Wno-error=stringop-overflow
+
 LIBS = -lCommon
 ifeq ($(CYGWIN), CYGWIN)
   LIBS += -L/lib/e2fsprogs -luuid

--- a/BaseTools/Source/C/GenFfs/GenFfs.c
+++ b/BaseTools/Source/C/GenFfs/GenFfs.c
@@ -542,7 +542,7 @@ GetAlignmentFromFile(char *InFile, UINT32 *Alignment)
   PeFileBuffer = (UINT8 *) malloc (PeFileSize);
   if (PeFileBuffer == NULL) {
     fclose (InFileHandle);
-    Error(NULL, 0, 4001, "Resource", "memory cannot be allocated  of %s", InFileHandle);
+    Error(NULL, 0, 4001, "Resource", "memory cannot be allocated for %s", InFile);
     return EFI_OUT_OF_RESOURCES;
   }
   fread (PeFileBuffer, sizeof (UINT8), PeFileSize, InFileHandle);

--- a/BaseTools/Source/C/GenSec/GenSec.c
+++ b/BaseTools/Source/C/GenSec/GenSec.c
@@ -1062,7 +1062,7 @@ GetAlignmentFromFile(char *InFile, UINT32 *Alignment)
   PeFileBuffer = (UINT8 *) malloc (PeFileSize);
   if (PeFileBuffer == NULL) {
     fclose (InFileHandle);
-    Error(NULL, 0, 4001, "Resource", "memory cannot be allocated  of %s", InFileHandle);
+    Error(NULL, 0, 4001, "Resource", "memory cannot be allocated for %s", InFile);
     return EFI_OUT_OF_RESOURCES;
   }
   fread (PeFileBuffer, sizeof (UINT8), PeFileSize, InFileHandle);

--- a/BaseTools/Source/C/LzmaCompress/Sdk/C/LzmaEnc.c
+++ b/BaseTools/Source/C/LzmaCompress/Sdk/C/LzmaEnc.c
@@ -2825,12 +2825,13 @@ SRes LzmaEnc_CodeOneMemBlock(CLzmaEncHandle pp, BoolInt reInit,
 
   nowPos64 = p->nowPos64;
   RangeEnc_Init(&p->rc);
-  p->rc.outStream = &outStream.vt;
 
   if (desiredPackSize == 0)
     return SZ_ERROR_OUTPUT_EOF;
 
+  p->rc.outStream = &outStream.vt;
   res = LzmaEnc_CodeOneBlock(p, desiredPackSize, *unpackSize);
+  p->rc.outStream = NULL;
 
   *unpackSize = (UInt32)(p->nowPos64 - nowPos64);
   *destLen -= outStream.rem;


### PR DESCRIPTION
Cherry-pick commits from upstream to fix building with GCC 12.

Test:

- Can build BaseTools using GCC 11
- Can build BaseTools using GCC 12

Ref: system76/firmware-open#313