### PR TITLE
Cherry-pick oprom commits for bonw14

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
@@ -2551,10 +2551,12 @@ PciEnumeratorLight (
       //
       RemoveRejectedPciDevices (RootBridgeDev->Handle, RootBridgeDev);
 
-      //
-      // Process option rom light
-      //
-      ProcessOptionRomLight (RootBridgeDev);
+      if (!PcdGetBool (PcdPciDisableBusEnumeration)) {
+        //
+        // Process option rom light
+        //
+        ProcessOptionRomLight (RootBridgeDev);
+      }
 
       //
       // Determine attributes for all devices under this root bridge

--- a/MdeModulePkg/Universal/SecurityStubDxe/Defer3rdPartyImageLoad.c
+++ b/MdeModulePkg/Universal/SecurityStubDxe/Defer3rdPartyImageLoad.c
@@ -25,7 +25,7 @@ typedef struct {
 } DEFERRED_3RD_PARTY_IMAGE_TABLE;
 
 BOOLEAN                          mImageLoadedAfterEndOfDxe   = FALSE;
-BOOLEAN                          mEndOfDxe                   = FALSE;
+BOOLEAN                          mEndOfDxe                   = TRUE;
 DEFERRED_3RD_PARTY_IMAGE_TABLE   mDeferred3rdPartyImage = {
   0,       // Deferred image count
   NULL     // The deferred image info


### PR DESCRIPTION
Cherry-pick 28d46822745c and d46c7763aa71 from [`system76-stable202002`](https://github.com/system76/edk2/tree/system76-stable202002) to potentially fix system76/firmware-open#442.

These don't appear to change behavior on oryp8 (issues with external displays at boot), but maybe affect bonw14?