### PR TITLE
UefiPayloadPkg: Add Intel GOP VBT file

### DIFF
--- a/UefiPayloadPkg/UefiPayloadPkg.fdf
+++ b/UefiPayloadPkg/UefiPayloadPkg.fdf
@@ -307,6 +307,11 @@ SET gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageFtwSpareSize = $(BLOCK_SIZE)
   !else
   INF  RuleOverride=BINARY USE = X64 $(FIRMWARE_OPEN_GOP_POLICY)
   !endif
+
+  FILE FREEFORM = 56752da9-de6b-4895-8819-1945b6b76c22 {
+    SECTION RAW = vbt.rom
+    SECTION UI = "IntelGopVbt"
+  }
 !endif
 !ifdef $(FIRMWARE_OPEN_GOP)
   # Use IntelGopDriver binary


### PR DESCRIPTION
Currently the VBT file is embedded into the system76-gop-policy driver. Add it to edk2 so it can be found in the FFS.

Ref: system76/gop-policy#20

### Test

Build a model in firmware-open that uses the GOP policy. Inspect `UEFIPAYLOAD.fd` with UEFITool:

- String "IntelGopVbt" is found in the image
- Body size of raw section matches `vbt.rom` in model directory